### PR TITLE
Fix kramdown auto_ids config syntax

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -44,7 +44,7 @@ redcarpet:
   extensions: []
 
 kramdown:
-  auto_ids: true,
+  auto_ids: true
   footnote_nr: 1
   entity_output: as_char
   toc_levels: 1..6


### PR DESCRIPTION
## Summary
- fix YAML for kramdown `auto_ids` by removing trailing comma so value is boolean

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68c737ed81b88328ad39c27afde55a03